### PR TITLE
Add back instrument name to connect button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2025-05-28
+
+* Fix: add back "Connect to {instrument}" for WebUSB connect button
+
 # 2025-05-27
 
 * Restructured the releases.json. Now the instruments are a top level structure with nested releases inside

--- a/src/app/Connector.jsx
+++ b/src/app/Connector.jsx
@@ -14,7 +14,7 @@ export default function Connector() {
   const [instructions, setInstructions] = useState("");
   const [filters, setFilters] = useState([]);
 
-  const { device, instrument, isWebUSBSupported, setErrorMsg } = useStore();
+  const { device, selectedInstrument, isWebUSBSupported, setErrorMsg } = useStore();
 
   const setDevice = (d) => {
     useStore.setState({ device: d });
@@ -52,7 +52,7 @@ export default function Connector() {
       .catch((error) => {
         setErrorMsg(`Error fetching instructions: ${error}`);
       });
-  }, []);
+  }, [setErrorMsg]);
 
   return (
     <div className="card bg-white text-primary-content w-full">
@@ -68,7 +68,7 @@ export default function Connector() {
                   className={`${device && "btn-disabled"} btn w-full`}
                   onClick={connectThisDevice}
                 >
-                  {device ? `${instrument} Connected` : `Connect to ${instrument}`}
+                  {device ? `${selectedInstrument} Connected` : `Connect to ${selectedInstrument}`}
                 </button>
               </div>
               <div className="card-actions justify-center flex items-center">


### PR DESCRIPTION
This adds back the instrument name to the connect button which got lost in PR #1.